### PR TITLE
inclination angle is deg

### DIFF
--- a/EPNTAP.tex
+++ b/EPNTAP.tex
@@ -2323,7 +2323,7 @@ equatorial\_radius&Float&km&&\ucd{phys.size.radius}\\
 polar\_radius&Float&km&&\ucd{phys.size.radius}\\
 diameter&Float&km&Target diameter, or equivalent diameter for binary objects&\ucd{phys.size.diameter}\\
 semi\_major\_axis&Float&AU&&\ucd{phys.size.smajAxis}\\
-inclination&Float&&Orbit inclination&\ucd{src.orbital.inclination}\\
+inclination&Float&deg&Orbit inclination&\ucd{src.orbital.inclination}\\
 eccentricity&Float&&Orbit eccentricity&\ucd{src.orbital.eccentricity}\\
 long\_asc&Float&deg&Longitude of ascending node, J2000.0&\ucd{src.orbital.node}\\
 arg\_perihel&Float&deg&Argument of Perihelion, J2000.0&\ucd{src.orbital.periastron}\\


### PR DESCRIPTION
Add unit "deg" for the [orbital] "inclination" field in the table
in Section 3.  Up till now the table listed no unit for this field.
But the text in sec 2.3.2 says "angles in degrees" and all existing
EPN-TAP services currently report this column with units of "deg".
So I think this was just an oversight.